### PR TITLE
fixing windows installation by removing * path assignment

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -80,9 +80,9 @@ docstring-convention = numpy
 profile=black
 src_paths=interpax,test
 
-[options.data_files]
-* =
-  *.txt
+# [options.data_files]
+# * =
+#   *.txt
 
 [requirements-files]
 # setuptools does not support "file:", so use a extra package for this:


### PR DESCRIPTION
hi,

thanks for the great package. i noticed the installation on windows is broken due to this block in the `setup.cfg`. in fact, it doesn't seem like it should be necessary at all. so in this PR, i remove this block to fix installation on windows

thanks