### PR TITLE
use eqx.error_if for runtime error checking. fixes #96

### DIFF
--- a/interpax/_ppoly.py
+++ b/interpax/_ppoly.py
@@ -136,8 +136,8 @@ class PPoly(eqx.Module):
         if check:
 
             dx = jnp.diff(x)
-            errorif(
-                jnp.any(dx < 0), ValueError, "`x` must be strictly increasing sequence."
+            dx = eqx.error_if(
+                dx, jnp.any(dx < 0), "`x` must be strictly increasing sequence."
             )
 
         self._extrapolate = extrapolate
@@ -472,24 +472,23 @@ def prepare_input(x, y, axis, dydx=None, check=True):
             ValueError,
             f"The length of `y` along `axis`={axis} doesn't match the length of `x`",
         )
-        errorif(
-            not jnp.all(jnp.isfinite(x)),
-            ValueError,
+        x = eqx.error_if(
+            x,
+            ~jnp.isfinite(x),
             "`x` must contain only finite values.",
         )
-        errorif(
-            not jnp.all(jnp.isfinite(y)),
-            ValueError,
+        f = eqx.error_if(
+            y,
+            ~jnp.isfinite(y),
             "`y` must contain only finite values.",
         )
-        errorif(
-            (dydx is not None) and (not jnp.all(jnp.isfinite(dydx))),
-            ValueError,
-            "`dydx` must contain only finite values.",
-        )
-        errorif(
-            jnp.any(dx <= 0), ValueError, "`x` must be strictly increasing sequence."
-        )
+        if dydx is not None:
+            dydx = eqx.error_if(
+                dydx,
+                ~jnp.isfinite(dydx),
+                "`dydx` must contain only finite values.",
+            )
+        dx = eqx.error_if(dx, dx <= 0, "`x` must be strictly increasing sequence.")
 
     return x, dx, y, axis, dydx
 

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -7,6 +7,7 @@ import pytest
 from jax import config as jax_config
 
 from interpax import (
+    CubicSpline,
     Interpolator1D,
     Interpolator2D,
     Interpolator3D,
@@ -546,3 +547,10 @@ def test_extrap_float():
     np.testing.assert_allclose(interpol(4.5, 5.3), 1.0)
     np.testing.assert_allclose(interpol(-4.5, 5.3), 0.0)
     np.testing.assert_allclose(interpol(4.5, -5.3), 0.0)
+
+
+@pytest.mark.unit
+def test_jittable_cubicspline():
+    x = jnp.linspace(0, 10, 10)
+    y = jnp.linspace(0, 8, 10)
+    res = jax.jit(CubicSpline)(x, y)


### PR DESCRIPTION
This uses eqx.error_if to enable error checking for runtime values. Allows for jitting PPoly and derived classes. 