### PR TITLE
Proper type hints for the library as a whole

### DIFF
--- a/interpax/__init__.py
+++ b/interpax/__init__.py
@@ -21,21 +21,21 @@ from ._spline import (
 )
 
 __all__ = [
-    'approx_df',
-    'fft_interp1d',
-    'fft_interp2d',
-    'Akima1DInterpolator',
-    'CubicHermiteSpline',
-    'CubicSpline',
-    'PchipInterpolator',
-    'PPoly',
-    'AbstractInterpolator',
-    'Interpolator1D',
-    'Interpolator2D',
-    'Interpolator3D',
-    'interp1d',
-    'interp2d',
-    'interp3d',
+    "approx_df",
+    "fft_interp1d",
+    "fft_interp2d",
+    "Akima1DInterpolator",
+    "CubicHermiteSpline",
+    "CubicSpline",
+    "PchipInterpolator",
+    "PPoly",
+    "AbstractInterpolator",
+    "Interpolator1D",
+    "Interpolator2D",
+    "Interpolator3D",
+    "interp1d",
+    "interp2d",
+    "interp3d",
 ]
 
 __version__ = _version.get_versions()["version"]


### PR DESCRIPTION
In the newest version, there are no proper type hints when importing any function:

![image](https://github.com/user-attachments/assets/55c22ef6-a8aa-408d-ab60-5804d423886f)

The import works on execution, but the vscode type hint shows an error. This PR should fix this issue.
