### PR TITLE
Improve FFT interpolation (1/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+- [Improves FFT interpolation](https://github.com/f0uriest/interpax/pull/116)
+  - The real FFT is now used where possible.
+  - Double the width of the Fourier spectrum is now preserved when interpolating to a less dense grid, at no additional cost.
+  - In the 2D upsampling case, the second transform is now padded only after computing the first transform. In the 2D downsampling case, the second transform is now truncated prior to computing the first transform. This reduces the size of the problem, so the computation is less expensive.
 - Adds a number of classes that replicate most of the functionality of the
 corresponding classes from scipy.interpolate :
   - ``scipy.interpolate.PPoly`` -> ``interpax.PPoly``
@@ -12,10 +16,6 @@ corresponding classes from scipy.interpolate :
 functions.
 - Method ``"monotonic"`` now works in 2D and 3D, where it will preserve monotonicity
 with respect to each coordinate individually.
-- [Improves FFT interpolation](https://github.com/f0uriest/interpax/pull/116)
-  - The real FFT is now used where possible.
-  - Double the width of the Fourier spectrum is now preserved when interpolating to a less dense grid, at no additional cost.
-  - In the 2D upsampling case, the second transform is now padded only after computing the first transform. In the 2D downsampling case, the second transform is now truncated prior to computing the first transform. This reduces the size of the problem, so the computation is less expensive.
 
 
 v0.2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ functions.
 with respect to each coordinate individually.
 - Upgrades FFT interpolation to use the real fast Fourier transform.
 - Upgrades FFT interpolation to preserve double the width of the frequency spectrum
-with negligible additional computation.
+with no additional computation.
 
 
 v0.2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ corresponding classes from scipy.interpolate :
 functions.
 - Method ``"monotonic"`` now works in 2D and 3D, where it will preserve monotonicity
 with respect to each coordinate individually.
+- Upgrades FFT interpolation to use the real fast Fourier transform.
+- Upgrades FFT interpolation to preserve double the width of the frequency spectrum
+with negligible additional computation.
 
 
 v0.2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ corresponding classes from scipy.interpolate :
 functions.
 - Method ``"monotonic"`` now works in 2D and 3D, where it will preserve monotonicity
 with respect to each coordinate individually.
-- Upgrades FFT interpolation to use the real fast Fourier transform.
-- Upgrades FFT interpolation to preserve double the width of the frequency spectrum
-with no additional computation.
+- [Improves FFT interpolation](https://github.com/f0uriest/interpax/pull/116)
+  - The real FFT is now used where possible.
+  - Double the width of the Fourier spectrum is now preserved when interpolating to a less dense grid, at no additional cost.
+  - In the 2D upsampling case, the second transform is now padded only after computing the first transform. In the 2D downsampling case, the second transform is now truncated prior to computing the first transform. This reduces the size of the problem, so the computation is less expensive.
 
 
 v0.2.4

--- a/interpax/_fourier.py
+++ b/interpax/_fourier.py
@@ -56,6 +56,7 @@ def _fft_interp1d(c, nx, n, sx, dx):
 
     x = jnp.linspace(0, dx * nx, n, endpoint=False)
     x = jnp.exp(1j * (c.shape[0] // 2) * x).reshape(n, *((1,) * (c.ndim - 1)))
+
     c = _fft_pad(c, n, 0)
     return (jnp.fft.ifft(c, axis=0, norm="forward") * x).real
 
@@ -116,8 +117,10 @@ def _fft_interp2d(c, nx, ny, n1, n2, sx, sy, dx, dy):
 
     y = jnp.linspace(0, dy * ny, n2, endpoint=False)
     y = jnp.exp(1j * (c.shape[1] // 2) * y).reshape(1, n2, *((1,) * (c.ndim - 2)))
+
+    c = jnp.fft.ifft(c, axis=0, norm="forward")
     c = _fft_pad(c, n2, 1)
-    return (jnp.fft.ifft2(c, axes=(0, 1), norm="forward") * y).real
+    return (jnp.fft.ifft(c, axis=1, norm="forward") * y).real
 
 
 def _fft_pad(c_shift, n_out, axis):

--- a/interpax/_fourier.py
+++ b/interpax/_fourier.py
@@ -98,17 +98,18 @@ def fft_interp2d(
 
 def _pad_along_axis(array: jax.Array, pad: tuple = (0, 0), axis: int = 0):
     """Pad with zeros or truncate a given dimension."""
-    array = jnp.moveaxis(array, axis, 0)
+    index = [slice(None)] * array.ndim
+    start = stop = None
 
     if pad[0] < 0:
-        array = array[abs(pad[0]) :]
+        start = abs(pad[0])
         pad = (0, pad[1])
     if pad[1] < 0:
-        array = array[: -abs(pad[1])]
+        stop = -abs(pad[1])
         pad = (pad[0], 0)
 
-    npad = [(0, 0)] * array.ndim
-    npad[0] = pad
+    index[axis] = slice(start, stop)
+    pad_width = [(0, 0)] * array.ndim
+    pad_width[axis] = pad
 
-    array = jnp.pad(array, pad_width=npad, mode="constant", constant_values=0)
-    return jnp.moveaxis(array, 0, axis)
+    return jnp.pad(array[tuple(index)], pad_width)

--- a/interpax/_fourier.py
+++ b/interpax/_fourier.py
@@ -54,7 +54,7 @@ def _fft_interp1d(c, nx, n, sx, dx):
         c = c.at[-1].divide(2)
     c = c.at[0].divide(2) * 2
 
-    x = jnp.linspace(0, dx * nx, n, endpoint=False)
+    x = jnp.linspace(0, 2 * jnp.pi, n, endpoint=False)
     x = jnp.exp(1j * (c.shape[0] // 2) * x).reshape(n, *((1,) * (c.ndim - 1)))
 
     c = _fft_pad(c, n, 0)
@@ -115,7 +115,7 @@ def _fft_interp2d(c, nx, ny, n1, n2, sx, sy, dx, dy):
         c = c.at[:, -1].divide(2)
     c = c.at[:, 0].divide(2) * 2
 
-    y = jnp.linspace(0, dy * ny, n2, endpoint=False)
+    y = jnp.linspace(0, 2 * jnp.pi, n2, endpoint=False)
     y = jnp.exp(1j * (c.shape[1] // 2) * y).reshape(1, n2, *((1,) * (c.ndim - 2)))
 
     c = jnp.fft.ifft(c, axis=0, norm="forward")

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -321,7 +321,7 @@ def test_fft_interp1d():
         fi = f1[sp][1]
         fs = fun(x[sp][1] + 0.2)
         np.testing.assert_allclose(
-            fs, fft_interp1d(fi, *fi.shape, sx=0.2, dx=np.diff(x[sp][1])[0]).squeeze()
+            fft_interp1d(fi, *fi.shape, sx=0.2, dx=np.diff(x[sp][1])[0]).squeeze(), fs
         )
         for ep in ["o", "e"]:  # eval parity
             for s in ["up", "down"]:  # up or downsample
@@ -333,7 +333,7 @@ def test_fft_interp1d():
                     xe = 1
                 true = fun(x[ep][xe])
                 interp = fft_interp1d(f1[sp][xs], x[ep][xe].size)
-                np.testing.assert_allclose(true, interp, atol=1e-12, rtol=1e-12)
+                np.testing.assert_allclose(interp, true, atol=1e-12, rtol=1e-12)
 
 
 @pytest.mark.unit
@@ -375,7 +375,6 @@ def test_fft_interp2d():
             fi = f2[spx][spy][1][1]
             fs = fun2(x[spx][1] + 0.2, y[spy][1] + 0.3)
             np.testing.assert_allclose(
-                fs,
                 fft_interp2d(
                     fi,
                     *fi.shape,
@@ -384,6 +383,7 @@ def test_fft_interp2d():
                     dx=np.diff(x[spx][1])[0],
                     dy=np.diff(y[spy][1])[0]
                 ).squeeze(),
+                fs,
             )
             for epx in ["o", "e"]:  # eval parity x
                 for epy in ["o", "e"]:  # eval parity y
@@ -406,7 +406,7 @@ def test_fft_interp2d():
                                 f2[spx][spy][xs][ys], x[epx][xe].size, y[epy][ye].size
                             )
                             np.testing.assert_allclose(
-                                true, interp, atol=1e-12, rtol=1e-12
+                                interp, true, atol=1e-12, rtol=1e-12
                             )
 
 

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -317,11 +317,12 @@ def test_fft_interp1d():
         for i in [1, 2]:
             f1[p][i] = fun(x[p][i])
 
+    sx = 0.2
     for sp in ["o", "e"]:  # source parity
         fi = f1[sp][1]
-        fs = fun(x[sp][1] + 0.2)
+        fs = fun(x[sp][1] + sx)
         np.testing.assert_allclose(
-            fft_interp1d(fi, *fi.shape, sx=0.2, dx=np.diff(x[sp][1])[0]).squeeze(), fs
+            fft_interp1d(fi, *fi.shape, sx, dx=x[sp][1][1] - x[sp][1][0]).squeeze(), fs
         )
         for ep in ["o", "e"]:  # eval parity
             for s in ["up", "down"]:  # up or downsample
@@ -331,8 +332,10 @@ def test_fft_interp1d():
                 else:
                     xs = 2
                     xe = 1
-                true = fun(x[ep][xe])
-                interp = fft_interp1d(f1[sp][xs], x[ep][xe].size)
+                true = fun(x[ep][xe] + sx)
+                interp = fft_interp1d(
+                    f1[sp][xs], x[ep][xe].size, sx, dx=x[sp][xs][1] - x[sp][xs][0]
+                ).squeeze()
                 np.testing.assert_allclose(interp, true, atol=1e-12, rtol=1e-12)
 
 
@@ -370,16 +373,18 @@ def test_fft_interp2d():
                 for j in [1, 2]:
                     f2[xp][yp][i][j] = fun2(x[xp][i], y[yp][j])
 
+    shiftx = 0.2
+    shifty = 0.3
     for spx in ["o", "e"]:  # source parity x
         for spy in ["o", "e"]:  # source parity y
             fi = f2[spx][spy][1][1]
-            fs = fun2(x[spx][1] + 0.2, y[spy][1] + 0.3)
+            fs = fun2(x[spx][1] + shiftx, y[spy][1] + shifty)
             np.testing.assert_allclose(
                 fft_interp2d(
                     fi,
                     *fi.shape,
-                    sx=0.2,
-                    sy=0.3,
+                    shiftx,
+                    shifty,
                     dx=np.diff(x[spx][1])[0],
                     dy=np.diff(y[spy][1])[0]
                 ).squeeze(),
@@ -401,10 +406,17 @@ def test_fft_interp2d():
                             else:
                                 ys = 2
                                 ye = 1
-                            true = fun2(x[epx][xe], y[epy][ye])
+
+                            true = fun2(x[epx][xe] + shiftx, y[epy][ye] + shifty)
                             interp = fft_interp2d(
-                                f2[spx][spy][xs][ys], x[epx][xe].size, y[epy][ye].size
-                            )
+                                f2[spx][spy][xs][ys],
+                                x[epx][xe].size,
+                                y[epy][ye].size,
+                                shiftx,
+                                shifty,
+                                dx=x[spx][xs][1] - x[spx][xs][0],
+                                dy=y[spy][ys][1] - y[spy][ys][0],
+                            ).squeeze()
                             np.testing.assert_allclose(
                                 interp, true, atol=1e-12, rtol=1e-12
                             )


### PR DESCRIPTION
This is the first of two pull requests to improve the FFT interpolation.

4 goals are achieved by this PR.

- [x] The real FFT is now used where possible. This is especially useful for 2D transforms. Resolves #75 .
- [x] Double the width of the Fourier spectrum is now preserved when interpolating to a less dense grid, **at no additional cost**. Previously, when the number of requested output samples $n_{\text{out}}$ was less than the number of input samples $n_{\text{in}}$, the interpolation would neglect the $n_{\text{in}} - n_{\text{out}}$ highest frequency spectral coefficients, resulting in **lossy** interpolation. Now the interpolation is **lossless** for all $n_{\text{out}} >= \lfloor n_{\text{in}} / 2 \rfloor + 1$. Likewise, if $n_{\text{out}} < \lfloor n_{\text{in}} / 2 \rfloor + 1$, then only the $\lfloor n_{\text{in}} / 2 \rfloor + 1 - n_{\text{out}}$ highest frequency spectral coefficients will be neglected.
- [x] In the 2D upsampling case, the second transform is now padded only after computing the first transform. This reduces the size of the problem, so the computation is less expensive.
- [x] In the 2D downsampling case, the second transform is now truncated prior to computing the first transform. This reduces the size of the problem, so the computation is less expensive.