### PR TITLE
Fix: avoid JAX array default arguments that initialize backend on import

### DIFF
--- a/interpax/_fd_derivs.py
+++ b/interpax/_fd_derivs.py
@@ -424,7 +424,7 @@ def _akima(x, f, axis):
     return jnp.moveaxis(df, 0, axis)
 
 
-def safediv(a: jax.Array, b: jax.Array, fill=jnp.array(0), threshold=jnp.array(0)):
+def safediv(a: jax.Array, b: jax.Array, fill=0, threshold=0):
     """Divide a/b with guards for division by zero.
 
     Parameters

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -1,5 +1,8 @@
 """Tests for interpolation functions."""
 
+import subprocess
+import sys
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -647,3 +650,26 @@ def test_extrap_float():
     np.testing.assert_allclose(interpol(4.5, 5.3), 1.0)
     np.testing.assert_allclose(interpol(-4.5, 5.3), 0.0)
     np.testing.assert_allclose(interpol(4.5, -5.3), 0.0)
+
+
+@pytest.mark.unit
+def test_import_does_not_initialize_jax_backend():
+    """Importing interpax must not trigger JAX backend initialization."""
+    script = """
+import jax
+jax.config.update('jax_enable_x64', True)
+import interpax  # noqa: F401
+import jax._src.xla_bridge as xb
+if xb._backends:
+    raise SystemExit(f"JAX backend initialized on import: {list(xb._backends)}")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"JAX backend was initialized during `import interpax`.\n"
+        f"stderr: {result.stderr}"
+    )

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -476,7 +476,7 @@ def test_fft_interp2d(dtype):
                 sx=0.2,
                 sy=0.3,
                 dx=np.diff(x[spx][1])[0],
-                dy=np.diff(y[spy][1])[0]
+                dy=np.diff(y[spy][1])[0],
             ).squeeze()
             np.testing.assert_allclose(
                 fs,


### PR DESCRIPTION
Hi,

first of all thanks for `interpax` - it's a great library and our scientific package [Raytrax](https://github.com/proximafusion/raytrax) wouldn't be possible without it.

Recently, a regression test that checks whether importing a package initializes JAX triggered with the latex `interpax` release and I traced it down (with Claude's help) to the `jnp.array(0)` default args in `safediv`.

This PR fixes it and adds a similar regression test. I hope it's ok to submit this without opening an issue first.

Background:

- Raytrax PR where regression test was introduced: https://github.com/proximafusion/raytrax/pull/20
- Original optimistix issue that motivated the regression test: https://github.com/patrick-kidger/optimistix/pull/186
- Raytrax PR that proves pinning interpax resolves the issue: https://github.com/proximafusion/raytrax/pull/35